### PR TITLE
Require Ruby 1.9 for the Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,11 +18,14 @@ GEM
       nokogiri (~> 1.4)
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (~> 0.0, >= 0.0.9)
+    mime-types (1.17.2)
     net-http-digest_auth (1.2)
     net-http-persistent (2.3.3)
     nokogiri (1.5.0)
     ntlm-http (0.1.1)
     rake (0.9.2.2)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
       rspec-expectations (~> 2.7.0)
@@ -49,6 +52,7 @@ DEPENDENCIES
   jeweler
   mechanize
   rake
+  rest-client
   rspec
   vcr (= 2.0.0.rc1)
   yard

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ Jeweler::Tasks.new do |gem|
   gem.description = %Q{Generic Web crawler with a DSL that parses structured data from web pages}
   gem.email = "felipe.lima@gmail.com"
   gem.authors = ["Felipe Lima"]
+  gem.required_ruby_version = ">= 1.9"
   # dependencies defined in Gemfile
 end
 

--- a/wombat.gemspec
+++ b/wombat.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Felipe Lima"]
-  s.date = "2012-02-15"
+  s.date = "2012-03-19"
   s.description = "Generic Web crawler with a DSL that parses structured data from web pages"
   s.email = "felipe.lima@gmail.com"
   s.extra_rdoc_files = [
@@ -54,7 +54,8 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/felipecsl/wombat"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.11"
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9")
+  s.rubygems_version = "1.8.15"
   s.summary = "Ruby DSL to crawl web pages"
 
   if s.respond_to? :specification_version then


### PR DESCRIPTION
The Gem is incompatible with older versions of Ruby. This patch adds the version requirement to the gemspec.

Maybe one should also check for RUBY_VERSION >= "1.9" in the code.
