### PR TITLE
Update lib/wombat/property_locator.rb

### DIFF
--- a/lib/wombat/property_locator.rb
+++ b/lib/wombat/property_locator.rb
@@ -12,7 +12,8 @@ module Wombat
 
     private
     def _locate(property)
-      result = select_nodes(property.selector, property.namespaces).to_a
+      result = select_nodes(property.selector, property.namespaces)
+      result = result.respond_to?(:to_a) ? result.to_a : [result]
       result.map! {|r| r.inner_html.strip } if property.format == :html
       result.map {|r| r.kind_of?(String) ? r : r.inner_text }.map(&:strip)
     end


### PR DESCRIPTION
Problem into v1.0.0 when element matched using xpath functions like concat 

xpath=concat(//div[1],//div[2])

The node returned it's a string literal(like textNode content), not a nokogiri node

Rise a exception at line 15 of file lib/wombat/property_locator.rb
