### PR TITLE
Update lib/wombat/property/locators/text.rb

### DIFF
--- a/lib/wombat/property/locators/text.rb
+++ b/lib/wombat/property/locators/text.rb
@@ -5,10 +5,9 @@ module Wombat
     module Locators
       class Text < Base
         def locate(context, page = nil)
-          node = locate_nodes(context) { |nodes|
-            nodes.is_a?(String) ? nodes : nodes.first
-          }
-          
+          node = locate_nodes(context)
+          node = node.first unless node.is_a?(String)
+
           value = 
             unless node
               nil

--- a/spec/property/locators/text_spec.rb
+++ b/spec/property/locators/text_spec.rb
@@ -11,7 +11,17 @@ describe Wombat::Property::Locators::Text do
 		locator = Wombat::Property::Locators::Text.new(property)
 	
 		locator.locate(context).should == { "data1" => "Something cool" }
-	end
+  end
+
+  it 'should locate text property with xpath selector using xpath functions' do
+    context   = double :context
+    context.stub(:xpath).with('concat(/abc, /def)', nil).and_return "    Something "
+    property = Wombat::DSL::Property.new('data1', 'xpath=concat(/abc, /def)', :text)
+
+    locator = Wombat::Property::Locators::Text.new(property)
+
+    locator.locate(context).should == { "data1" => "Something" }
+  end
 
 	it 'should locate text property with css selector' do
 		fake_elem = double :element


### PR DESCRIPTION
Fix matches using xpath functions like "concat", for example:

xpath=concat(//div[@id="name"], " : ", //span[@class="status"])

It returns a string literal, not a textNode with content from nokogiri node.
