### PR TITLE
Refactor retry page.click on relative link

### DIFF
--- a/lib/wombat/processing/parser.rb
+++ b/lib/wombat/processing/parser.rb
@@ -10,6 +10,11 @@ module Nokogiri
       attr_accessor :headers
     end
   end
+  module HTML
+    class Document
+      attr_accessor :mechanize_page
+    end
+  end
 end
 
 module Wombat
@@ -38,7 +43,8 @@ module Wombat
 
           if metadata[:document_format] == :html
             @page = @mechanize.get(url) unless @page
-            parser = @page.parser
+            parser = @page.parser         # Nokogiri::HTML::Document
+            parser.mechanize_page = @page # Mechanize::Page 
             parser.headers = @page.header
           else
             @page = RestClient.get(url) unless @page

--- a/lib/wombat/property/locators/follow.rb
+++ b/lib/wombat/property/locators/follow.rb
@@ -7,36 +7,13 @@ module Wombat
 	    	def locate(context, page = nil)
 	    		super do
             locate_nodes(context).flat_map do |node|
-              retried = false
-              begin
-                # Certain erroneous pages contain http 
-                # links with relative href attribute, 
-                # while browsers actually use them as 
-                # absolute.
-                # So, let wombat try that approach when 
-                # loading relative link fails.
-                #
-                target_page = page.click node
-                context = target_page.parser
+              mechanize_page = context.mechanize_page
+              link = Mechanize::Page::Link.new(node, page, mechanize_page)
+              target_page = page.click link
+              context = target_page.parser
+              context.mechanize_page = mechanize_page
 
-                filter_properties(context, page)
-              rescue Mechanize::ResponseCodeError => e
-                # Either the page is unavailable, or
-                # the link is mistakenly relative
-                #
-                raise e if retried
-                
-                # Give it a try first time
-                href = node.attributes && node.attributes["href"]
-                if href.respond_to? :value
-                  href.value = '/' + href.value unless 
-                    href.value.start_with? '/'
-                  retried = true
-                  retry
-                else
-                  raise e
-                end
-              end
+              filter_properties(context, page)
             end
           end
 	    	end

--- a/spec/processing/parser_spec.rb
+++ b/spec/processing/parser_spec.rb
@@ -17,6 +17,7 @@ describe Wombat::Processing::Parser do
     fake_document.should_receive(:parser).and_return(fake_parser)
     fake_document.should_receive(:header).and_return(fake_header)
     fake_parser.should_receive(:headers=)
+    fake_parser.should_receive(:mechanize_page=)
     @parser.mechanize.should_receive(:get).with("http://www.google.com/search").and_return fake_document
 
     @parser.parse @metadata


### PR DESCRIPTION
Hi, Felipe
I refactored the previous solution. It retrieves a page at the first attempt with no retry, It properly handles links with references from the current page ../../.. and it's written cleaner