### PR TITLE
Allow crawler classes inheritance

### DIFF
--- a/lib/wombat/crawler.rb
+++ b/lib/wombat/crawler.rb
@@ -10,6 +10,13 @@ module Wombat
     include Processing::Parser
     extend ActiveSupport::Concern
 
+    included do
+      class << self
+        attr_accessor :metadata
+      end
+      self.metadata = DSL::Metadata.new
+    end
+
     def crawl(&block)
       if block
         @metadata_dup = self.class.send(:metadata).clone
@@ -45,9 +52,8 @@ module Wombat
       def to_ary
       end
 
-      private
-      def metadata
-        @metadata ||= DSL::Metadata.new
+      def inherited(subclass)
+        subclass.metadata = self.metadata.clone
       end
     end
   end

--- a/lib/wombat/processing/parser.rb
+++ b/lib/wombat/processing/parser.rb
@@ -57,7 +57,7 @@ module Wombat
           if metadata[:document_format] == :html
             @page = @mechanize.public_send(_method, *args) unless @page
             parser = @page.parser         # Nokogiri::HTML::Document
-            parser.mechanize_page = @page # Mechanize::Page 
+            parser.mechanize_page = @page # Mechanize::Page
             parser.headers = @page.header
           else
             @page = RestClient.public_send(_method, *args) unless @page

--- a/spec/integration/crawler_inheritance_spec.rb
+++ b/spec/integration/crawler_inheritance_spec.rb
@@ -1,6 +1,5 @@
 # coding: utf-8
 require 'spec_helper'
-require 'byebug'
 
 describe 'crawler base and one derived class' do
   class A

--- a/spec/integration/crawler_inheritance_spec.rb
+++ b/spec/integration/crawler_inheritance_spec.rb
@@ -1,0 +1,64 @@
+# coding: utf-8
+require 'spec_helper'
+require 'byebug'
+
+describe 'crawler base and one derived class' do
+  class A
+    include Wombat::Crawler
+    title 'xpath=//head/title'
+  end
+
+  class B < A
+    base_url "http://www.terra.com.br"
+    path "/portal"
+    search "css=.btn-search"
+  end
+
+  it 'extracts properties defined in the base class ' do
+    VCR.use_cassette('basic_crawler_page') do
+      b = B.new
+      data = b.crawl
+      expect(data).to have_key('title')
+      expect(data).to have_key('search')
+    end
+  end
+end
+
+describe 'two derived classes' do
+  class D
+    include Wombat::Crawler
+    title 'xpath=//head/title'
+  end
+
+  class E < D
+    base_url "http://www.terra.com.br"
+    path "/portal"
+    search "css=.btn-search"
+  end
+
+  class F < D
+    title 'xpath=//broken/badly'
+    base_url "https://www.github.com"
+    path "/"
+  end
+
+
+  it 'second derived class does not overwrite base class properties' do
+    VCR.use_cassette('basic_crawler_page') do
+      e = E.new
+      data = e.crawl
+      expect(data).to have_key('title')
+      expect(data).to have_key('search')
+      expect(data['title']).to eq('Terra - Notícias, vídeos, esportes, economia, diversão, música, moda, fotolog, blog, chat')
+    end
+  end
+
+  it 'first derived class does not overwrite base class properties' do
+    VCR.use_cassette('follow_links') do
+      f = F.new
+      data = f.crawl
+      expect(data).to have_key('title')
+      expect(data['title']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Currently, this configuration doesn't work:
```ruby
  class A
    include Wombat::Crawler
    title 'xpath=//head/title'
  end

  class B < A
    base_url "http://www.terra.com.br"
    path "/portal"
    search "css=.btn-search"
  end

  b = B.new
  b.crawl
```

This is because the properties are saved in an instance variable of the class. That makes B and A properties entirely separate and when `b.crawl` is called, only the properties defined in B are collected, the "title" property defined in A is ignored.

This patch makes sure the base class properties are included in the derived class by cloning them at the time the base class is subclassed.