### PR TITLE
Url as crawl argument

### DIFF
--- a/lib/wombat/crawler.rb
+++ b/lib/wombat/crawler.rb
@@ -17,7 +17,7 @@ module Wombat
       self.metadata = DSL::Metadata.new
     end
 
-    def crawl(&block)
+    def crawl(url = nil, &block)
       if block
         @metadata_dup = self.class.send(:metadata).clone
         instance_eval do
@@ -27,14 +27,14 @@ module Wombat
           end
         end
         self.instance_eval &block
-        parsed = parse @metadata_dup
+        parsed = parse(@metadata_dup, url)
         instance_eval do
           alias :method_missing :old_method_missing
           remove_instance_variable :@metadata_dup
         end
         parsed
       else
-        parse self.class.send(:metadata)
+        parse(self.class.send(:metadata), url)
       end
     end
 

--- a/lib/wombat/processing/parser.rb
+++ b/lib/wombat/processing/parser.rb
@@ -37,15 +37,15 @@ module Wombat
         @mechanize.user_agent_alias = Wombat.user_agent_alias if Wombat.user_agent_alias
       end
 
-      def parse(metadata)
-        @context = parser_for metadata
+      def parse(metadata, url=nil)
+        @context = parser_for(metadata, url)
 
         Wombat::Property::Locators::Factory.locator_for(metadata).locate(@context, @mechanize)
       end
 
       private
-      def parser_for(metadata)
-        url = "#{metadata[:base_url]}#{metadata[:path]}"
+      def parser_for(metadata, url)
+        url ||= "#{metadata[:base_url]}#{metadata[:path]}"
         page = nil
         parser = nil
         _method = method_from(metadata[:http_method])

--- a/spec/crawler_spec.rb
+++ b/spec/crawler_spec.rb
@@ -131,6 +131,19 @@ describe Wombat::Crawler do
       another_instance.crawl
     end
 
+    it 'should crawl with url and block' do
+      url = 'http://danielinc.com/itens'
+
+      expect(@crawler_instance).to receive(:parse).with(anything, url)
+      @crawler_instance.crawl(url) do
+      end
+
+      another_instance = @crawler.new
+      expect(another_instance).to receive(:parse).with(anything, url)
+
+      another_instance.crawl(url)
+    end
+
     it 'should remove created method missing' do
       @crawler.base_url "danielnc.com"
       @crawler.path "/itens"

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -292,4 +292,15 @@ describe 'basic crawler setup' do
       results["my_name"].should eq("your_name = Name")
     end
   end
+
+  it 'should let the url be passed as an argument to crawl' do
+    VCR.use_cassette('basic_crawler_page') do
+      crawler = Class.new
+      crawler.send(:include, Wombat::Crawler)
+      crawler.send(:title, 'xpath=//head/title')
+      crawler_instance = crawler.new
+      results = crawler_instance.crawl('http://www.terra.com.br/portal')
+      results['title'].should eq('Terra - Notícias, vídeos, esportes, economia, diversão, música, moda, fotolog, blog, chat')
+    end
+  end
 end

--- a/spec/processing/parser_spec.rb
+++ b/spec/processing/parser_spec.rb
@@ -42,6 +42,21 @@ describe Wombat::Processing::Parser do
     @parser.parse @metadata
   end
 
+  it 'should accept the url as an argument to parse' do
+    @metadata.http_method :get
+
+    fake_document = double :document
+    fake_parser = double :parser
+    fake_header = double :header
+    fake_document.should_receive(:parser).and_return(fake_parser)
+    fake_document.should_receive(:header).and_return(fake_header)
+    fake_parser.should_receive(:headers=)
+    fake_parser.should_receive(:mechanize_page=)
+    @parser.mechanize.should_receive(:get).with("https://www.github.com/notifications").and_return fake_document
+
+    @parser.parse(@metadata, 'https://www.github.com/notifications')
+  end
+
   it 'should correctly parse xml documents' do
     fake_document = double :xml
     fake_parser = double :parser


### PR DESCRIPTION
The way I use Wombat or rather the way I'd like to use it is to define a crawler class per website and then instantiate the crawler class to parse any number of pages of the same website.

It works like this:
 ```ruby
class TheWebsiteCrawler
  include Wombat::Crawler

  some_data css: "div.elemClass .anchor"
  another_info xpath: "//my/xpath[@style='selector']"
end

crawler = TheWebsiteCrawler.new
scraped_data_one = crawler.crawl("http://the-website.com/page_one")
scraped_data_two = crawler.crawl("http://the-website.com/page_two")
```

This is not possible with the current interface since the base_url and path must defined at the class level. This pull request makes it possible to pass the url to the crawl method and skip base_url and path while defining the class. Of course, it's still possible to use Wombat the traditional way. 