### PR TITLE
Ensure that CI also runs on the master branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Wombat CI
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   test:


### PR DESCRIPTION
Right now CI is only running on pull requests.  It's usually helpful to have CI run on the master/main branch to show users of the gem that everything is green.  This configuration change will cause CI to run on master when a PR is merged (or a push is made directly).